### PR TITLE
Don't allow users to create incidents for years that were already submitted by their ORI

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -91,8 +91,10 @@ class ApplicationController < ActionController::Base
     def check_authorization
       if !@incident.authorized_to_view?(@current_user)
         raise BridgeExceptions::UnathorizedToView.new
-      elsif !@incident.authorized_to_edit?(@current_user) && params[:action] != 'review'
-        redirect_to review_incident_path(@incident)
+      elsif !@incident.authorized_to_edit?(@current_user)
+        raise BridgeExceptions::UnathorizedToView.new if @incident.next_step != :review
+
+        redirect_to review_incident_path(@incident) if params[:action] != 'review'
       end
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,8 +69,9 @@ class ApplicationController < ActionController::Base
 
     # Calls update_attributes on a given model and (if sucessful) saves an AuditEntry
     # with a record of all changed fields to the given Incident.
+    # Call with ready_to_save=false to run validation but not save the AuditEntry.
     # Returns true if changes were saved, false if they failed to save.
-    def save_and_audit(model, attributes, ready_to_save)
+    def save_and_audit(model, attributes, ready_to_save=true)
       # Save existing model state.
       old_values = Hash[attributes.keys.map { |k| [k, model.send(k)] }]
       is_new = !model.persisted?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,15 +69,14 @@ class ApplicationController < ActionController::Base
 
     # Calls update_attributes on a given model and (if sucessful) saves an AuditEntry
     # with a record of all changed fields to the given Incident.
-    # Call with ready_to_save=false to run validation but not save the AuditEntry.
     # Returns true if changes were saved, false if they failed to save.
-    def save_and_audit(model, attributes, ready_to_save = true)
+    def save_and_audit(model, attributes)
       # Save existing model state.
       old_values = Hash[attributes.keys.map { |k| [k, model.send(k)] }]
       is_new = !model.persisted?
 
       # Update the model and save the audit entry (if valid).
-      if model.update_attributes(attributes) && ready_to_save
+      if model.update_attributes(attributes)
         build_audit_entry(model, attributes, old_values, is_new)
         true
       else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,13 +70,13 @@ class ApplicationController < ActionController::Base
     # Calls update_attributes on a given model and (if sucessful) saves an AuditEntry
     # with a record of all changed fields to the given Incident.
     # Returns true if changes were saved, false if they failed to save.
-    def save_and_audit(model, attributes)
+    def save_and_audit(model, attributes, ready_to_save)
       # Save existing model state.
       old_values = Hash[attributes.keys.map { |k| [k, model.send(k)] }]
       is_new = !model.persisted?
 
       # Update the model and save the audit entry (if valid).
-      if model.update_attributes(attributes)
+      if model.update_attributes(attributes) && ready_to_save
         build_audit_entry(model, attributes, old_values, is_new)
         true
       else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,7 @@ class ApplicationController < ActionController::Base
     # with a record of all changed fields to the given Incident.
     # Call with ready_to_save=false to run validation but not save the AuditEntry.
     # Returns true if changes were saved, false if they failed to save.
-    def save_and_audit(model, attributes, ready_to_save=true)
+    def save_and_audit(model, attributes, ready_to_save = true)
       # Save existing model state.
       old_values = Hash[attributes.keys.map { |k| [k, model.send(k)] }]
       is_new = !model.persisted?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,9 +92,12 @@ class ApplicationController < ActionController::Base
       if !@incident.authorized_to_view?(@current_user)
         raise BridgeExceptions::UnathorizedToView.new
       elsif !@incident.authorized_to_edit?(@current_user)
-        raise BridgeExceptions::UnathorizedToView.new if @incident.next_step != :review
-
-        redirect_to review_incident_path(@incident) if params[:action] != 'review'
+        # Redirect to review page if possible.
+        if @incident.next_step != :review
+          raise BridgeExceptions::UnathorizedToView.new
+        elsif params[:action] != 'review'
+          redirect_to review_incident_path(@incident)
+        end
       end
     end
 

--- a/app/controllers/general_infos_controller.rb
+++ b/app/controllers/general_infos_controller.rb
@@ -36,13 +36,7 @@ class GeneralInfosController < StepsBaseController
   private
 
     def set_general_info
-      @general_info = @incident.general_info.target || GeneralInfo.new
-
-      # Give the GeneralInfo model :ori and :current_user_id attributes,
-      # that are necessary for validation (because the GeneralInfo model doesn't
-      # have a corresponding Incident until *after* validation).
-      @general_info.default_ori = @incident.ori
-      @general_info.current_user_id = @current_user.user_id
+      @general_info = @incident.general_info.target || GeneralInfo.new(incident: @incident)
     end
 
     def partial_save(formatted_params)

--- a/app/controllers/general_infos_controller.rb
+++ b/app/controllers/general_infos_controller.rb
@@ -20,13 +20,11 @@ class GeneralInfosController < StepsBaseController
       old_incident = { ori: @incident.ori, year: @incident.year }
 
       # Try to validate, save, and audit the updated fields.
-      unless save_and_audit(@general_info, formatted_params)
-        return render :edit
-      end
+      return render :edit unless save_and_audit(@general_info, formatted_params)
 
       # Update successful, fields valid.
       @incident.general_info = @general_info
-      @incident.ori = @ori
+      @incident.ori = @general_info.contacting_for_ori if @general_info.contacting_for_ori
 
       regenerate_incident_id_if_necessary!(old_incident)
       remove_people_if_necessary_to_match_counts!

--- a/app/controllers/general_infos_controller.rb
+++ b/app/controllers/general_infos_controller.rb
@@ -24,7 +24,7 @@ class GeneralInfosController < StepsBaseController
 
       # Update successful, fields valid.
       @incident.general_info = @general_info
-      @incident.ori = @general_info.contracting_for_ori if @general_info.contacting_for_ori
+      @incident.ori = @general_info.contracting_for_ori if @general_info.contracting_for_ori
 
       regenerate_incident_id_if_necessary!(old_incident)
       remove_people_if_necessary_to_match_counts!

--- a/app/controllers/general_infos_controller.rb
+++ b/app/controllers/general_infos_controller.rb
@@ -24,7 +24,7 @@ class GeneralInfosController < StepsBaseController
 
       # Update successful, fields valid.
       @incident.general_info = @general_info
-      @incident.ori = @general_info.contacting_for_ori if @general_info.contacting_for_ori
+      @incident.ori = @general_info.contracting_for_ori if @general_info.contacting_for_ori
 
       regenerate_incident_id_if_necessary!(old_incident)
       remove_people_if_necessary_to_match_counts!

--- a/app/controllers/general_infos_controller.rb
+++ b/app/controllers/general_infos_controller.rb
@@ -19,10 +19,18 @@ class GeneralInfosController < StepsBaseController
       # Save the incident ORI and year, so that we can later check if it's changed.
       old_incident = { ori: @incident.ori, year: @incident.year }
 
-      # Try to validate, save, and audit the updated fields
-      check_that_ori_is_valid(formatted_params)
-      save_succeeded = save_and_audit(@general_info, formatted_params)
-      return render :edit unless save_succeeded
+      # Try to validate, save, and audit the updated fields.
+      # Note that validate_ori() and validate_incident_year() are special validators that
+      # require knowledge of the submitting ORI and so must be run at the controller
+      # level rather than at the model level with the other validators.
+      ready_to_save = validate_ori(formatted_params) && validate_incident_year(formatted_params)
+      save_succeeded = save_and_audit(@general_info, formatted_params, ready_to_save)
+      unless save_succeeded
+        # Re-run the ori and incident_year validators because save_and_audit() cleared their error messages.
+        validate_ori(formatted_params)
+        validate_incident_year(formatted_params)
+        return render :edit
+      end
 
       # Update successful, fields valid.
       @incident.general_info = @general_info
@@ -47,13 +55,36 @@ class GeneralInfosController < StepsBaseController
       redirect_to dashboard_path
     end
 
-    # Check that the incident ORI is allowed. (We can't do this check on the model level
-    # b/c the GeneralInfo model doesn't have access to the incident or user yet.)
-    # If invalid, adds an error to the GeneralInfo model.
-    def check_that_ori_is_valid(formatted_params)
+    # Check that the incident ORI is allowed.
+    # (We can't do this check on the model level b/c the GeneralInfo model
+    # doesn't have access to the incident or user yet.)
+    # If invalid, returns false and adds an error to the GeneralInfo model.
+    def validate_ori(formatted_params)
       @ori = formatted_params['contracting_for_ori'] || @incident.ori
       if @current_user.allowed_oris.exclude? @ori
         @general_info.errors.add(:contracting_for_ori, "invalid ORI")
+        false
+      else
+        true
+      end
+    end
+
+    # Check that the incident's year hasn't been submitted by the user's agency yet.
+    # (We can't do this check on the model level b/c the GeneralInfo model
+    # doesn't have access to the incident or user yet.)
+    # If invalid, returns false and adds an error to the GeneralInfo model.
+    def validate_incident_year(formatted_params)
+      date_str = formatted_params['incident_date_str']
+      year = date_str.split('/').last.to_i
+
+      ori = formatted_params['contracting_for_ori'] || @incident.ori
+      agency_status = AgencyStatus.find_or_create_by_ori(ori)
+
+      if agency_status.complete_submission_years.include? year
+        @general_info.errors.add(:incident_date_str, "ORI #{ori} has already submitted for this year")
+        false
+      else
+        true
       end
     end
 

--- a/app/controllers/general_infos_controller.rb
+++ b/app/controllers/general_infos_controller.rb
@@ -36,7 +36,13 @@ class GeneralInfosController < StepsBaseController
   private
 
     def set_general_info
-      @general_info = @incident.general_info.target || GeneralInfo.new(incident: @incident)
+      if @incident.general_info.present?
+        @general_info = @incident.general_info.target
+      else
+        @general_info = GeneralInfo.new(incident: @incident)
+        # Setting general_info.incident causes validation to run, so clear those errors.
+        @general_info.errors.clear
+      end
     end
 
     def partial_save(formatted_params)

--- a/app/models/agency_status.rb
+++ b/app/models/agency_status.rb
@@ -19,6 +19,10 @@ class AgencyStatus
     end
   end
 
+  def self.find_or_create_by_ori(ori)
+    find_by_ori(ori) || create(ori: ori)
+  end
+
   def self.find_by_ori(ori)
     find(ori)  # Since ORI is the primary key
   end

--- a/app/models/general_info.rb
+++ b/app/models/general_info.rb
@@ -27,6 +27,12 @@ class GeneralInfo
   field :num_involved_civilians, :integer
   field :num_involved_officers, :integer
 
+  # These fields are written prior to validation in order to validate the ORI and year.
+  # This is necessary because the GeneralInfo model doesn't have a corresponding Incident
+  # until *after* validation.
+  field :current_user_id, :string
+  field :default_ori, :string
+
   validates :incident_date_str, incident_date: true
   validates :incident_time_str, incident_time: true
   validates :address, presence: true
@@ -43,6 +49,7 @@ class GeneralInfo
   validates :num_involved_civilians, :num_involved_officers,
             numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 20,
                             message: "should be a positive number (1-20)" }
+  validates :contracting_for_ori, ori: true
 
   delegate :incident_id, to: :incident
 

--- a/app/models/general_info.rb
+++ b/app/models/general_info.rb
@@ -27,12 +27,6 @@ class GeneralInfo
   field :num_involved_civilians, :integer
   field :num_involved_officers, :integer
 
-  # These fields are written prior to validation in order to validate the ORI and year.
-  # This is necessary because the GeneralInfo model doesn't have a corresponding Incident
-  # until *after* validation.
-  field :current_user_id, :string
-  field :default_ori, :string
-
   validates :incident_date_str, incident_date: true
   validates :incident_time_str, incident_time: true
   validates :address, presence: true
@@ -86,6 +80,6 @@ class GeneralInfo
     end
 
     def upcase_state
-      state.upcase!
+      state.upcase! if state
     end
 end

--- a/app/models/global_state.rb
+++ b/app/models/global_state.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 # This class is a singleton (see HasOnlyOneInstance).
 # Use the accessor functions below to get and set.
 class GlobalState

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -39,16 +39,20 @@ class Incident
   end
 
   def next_step
-    if screener.nil? || screener.invalid?
-      :screener
-    elsif general_info.nil? || general_info.invalid?
-      :general_info
-    elsif involved_civilians.to_a.count(&:valid?) < general_info.num_involved_civilians
-      :involved_civilians
-    elsif involved_officers.to_a.count(&:valid?) < general_info.num_involved_officers
-      :involved_officers
-    else
+    if submitted?
       :review
+    else
+      if screener.nil? || screener.invalid?
+        :screener
+      elsif general_info.nil? || general_info.invalid?
+        :general_info
+      elsif involved_civilians.to_a.count(&:valid?) < general_info.num_involved_civilians
+        :involved_civilians
+      elsif involved_officers.to_a.count(&:valid?) < general_info.num_involved_officers
+        :involved_officers
+      else
+        :review
+      end
     end
   end
 

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -40,19 +40,19 @@ class Incident
 
   def next_step
     if submitted?
+      # Don't run validation for submitted incidents because
+      # we already know they're completely valid.
       :review
+    elsif screener.nil? || screener.invalid?
+      :screener
+    elsif general_info.nil? || general_info.invalid?
+      :general_info
+    elsif involved_civilians.to_a.count(&:valid?) < general_info.num_involved_civilians
+      :involved_civilians
+    elsif involved_officers.to_a.count(&:valid?) < general_info.num_involved_officers
+      :involved_officers
     else
-      if screener.nil? || screener.invalid?
-        :screener
-      elsif general_info.nil? || general_info.invalid?
-        :general_info
-      elsif involved_civilians.to_a.count(&:valid?) < general_info.num_involved_civilians
-        :involved_civilians
-      elsif involved_officers.to_a.count(&:valid?) < general_info.num_involved_officers
-        :involved_officers
-      else
-        :review
-      end
+      :review
     end
   end
 

--- a/app/validators/incident_date_validator.rb
+++ b/app/validators/incident_date_validator.rb
@@ -4,15 +4,21 @@ class IncidentDateValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     valid_years = GlobalState.valid_new_incident_years
+    valid_years_str = valid_years.to_a.join(' or ')
+
     begin
       raise ArgumentError unless value =~ DATE_REGEX
       date = Date.strptime(value, '%m/%d/%Y')
 
+      ori = record.contracting_for_ori || record.default_ori
+      agency_status = AgencyStatus.find_or_create_by_ori(ori)
+
       if valid_years.exclude? date.year
-        record.errors[attribute] << "invalid year #{date.year} " \
-                                    "- you can only create incidents for #{valid_years.to_a.join(' or ')}"
+        record.errors[attribute] << "invalid year #{date.year} - you can only create incidents for #{valid_years_str}"
       elsif date > Time.zone.today
         record.errors[attribute] << "future date #{value} not allowed (today is #{Time.zone.today.strftime('%m/%d/%Y')})"
+      elsif agency_status.complete_submission_years.include? date.year
+        record.errors[attribute] << "ORI #{ori} has already submitted for this year"
       end
     rescue ArgumentError
       record.errors[attribute] << "must be a valid date in MM/DD/YYYY format (you gave #{value})"

--- a/app/validators/incident_date_validator.rb
+++ b/app/validators/incident_date_validator.rb
@@ -10,7 +10,7 @@ class IncidentDateValidator < ActiveModel::EachValidator
       raise ArgumentError unless value =~ DATE_REGEX
       date = Date.strptime(value, '%m/%d/%Y')
 
-      ori = record.contracting_for_ori || record.default_ori
+      ori = record.contracting_for_ori || record.incident.ori
       agency_status = AgencyStatus.find_or_create_by_ori(ori) if ori
 
       if valid_years.exclude? date.year

--- a/app/validators/incident_date_validator.rb
+++ b/app/validators/incident_date_validator.rb
@@ -11,7 +11,7 @@ class IncidentDateValidator < ActiveModel::EachValidator
       date = Date.strptime(value, '%m/%d/%Y')
 
       ori = record.contracting_for_ori || record.default_ori
-      agency_status = ori ? AgencyStatus.find_or_create_by_ori(ori) : nil
+      agency_status = AgencyStatus.find_or_create_by_ori(ori) if ori
 
       if valid_years.exclude? date.year
         record.errors[attribute] << "invalid year #{date.year} - you can only create incidents for #{valid_years_str}"

--- a/app/validators/incident_date_validator.rb
+++ b/app/validators/incident_date_validator.rb
@@ -28,13 +28,13 @@ class IncidentDateValidator < ActiveModel::EachValidator
     # been submitted for by the given ORI.
     def validate_year_not_submitted_yet(record, attribute, year)
       incident = record.incident.target
-      ori = record.contracting_for_ori || incident.try(:ori)
 
       # Only perform this check if the GeneralInfo model has an associated incident
-      # (this may not be the case, i.e. when the incident is being created
-      # via bulk upload) and the incident hasn't been submitted yet.
-      if incident.present? && !incident.submitted?
+      # (this may not be the case, i.e. when the incident is being created via bulk upload).
+      if incident.present?
+        ori = record.contracting_for_ori || incident.ori
         submitted_years = AgencyStatus.find_or_create_by_ori(ori).complete_submission_years
+
         if submitted_years.include? year
           record.errors[attribute] << "ORI #{ori} has already submitted for this year"
         end

--- a/app/validators/incident_date_validator.rb
+++ b/app/validators/incident_date_validator.rb
@@ -11,13 +11,13 @@ class IncidentDateValidator < ActiveModel::EachValidator
       date = Date.strptime(value, '%m/%d/%Y')
 
       ori = record.contracting_for_ori || record.default_ori
-      agency_status = AgencyStatus.find_or_create_by_ori(ori)
+      agency_status = ori ? AgencyStatus.find_or_create_by_ori(ori) : nil
 
       if valid_years.exclude? date.year
         record.errors[attribute] << "invalid year #{date.year} - you can only create incidents for #{valid_years_str}"
       elsif date > Time.zone.today
         record.errors[attribute] << "future date #{value} not allowed (today is #{Time.zone.today.strftime('%m/%d/%Y')})"
-      elsif agency_status.complete_submission_years.include? date.year
+      elsif agency_status && agency_status.complete_submission_years.include?(date.year)
         record.errors[attribute] << "ORI #{ori} has already submitted for this year"
       end
     rescue ArgumentError

--- a/app/validators/incident_date_validator.rb
+++ b/app/validators/incident_date_validator.rb
@@ -10,18 +10,34 @@ class IncidentDateValidator < ActiveModel::EachValidator
       raise ArgumentError unless value =~ DATE_REGEX
       date = Date.strptime(value, '%m/%d/%Y')
 
-      ori = record.contracting_for_ori || record.incident.ori
-      agency_status = AgencyStatus.find_or_create_by_ori(ori) if ori
-
       if valid_years.exclude? date.year
         record.errors[attribute] << "invalid year #{date.year} - you can only create incidents for #{valid_years_str}"
       elsif date > Time.zone.today
         record.errors[attribute] << "future date #{value} not allowed (today is #{Time.zone.today.strftime('%m/%d/%Y')})"
-      elsif agency_status && agency_status.complete_submission_years.include?(date.year)
-        record.errors[attribute] << "ORI #{ori} has already submitted for this year"
+      else
+        validate_year_not_submitted_yet(record, attribute, date.year)
       end
     rescue ArgumentError
       record.errors[attribute] << "must be a valid date in MM/DD/YYYY format (you gave #{value})"
     end
   end
+
+  private
+
+    # Ensure that the incident is not being created for a year that has already
+    # been submitted for by the given ORI.
+    def validate_year_not_submitted_yet(record, attribute, year)
+      incident = record.incident.target
+      ori = record.contracting_for_ori || incident.try(:ori)
+
+      # Only perform this check if the GeneralInfo model has an associated incident
+      # (this may not be the case, i.e. when the incident is being created
+      # via bulk upload) and the incident hasn't been submitted yet.
+      if incident.present? && !incident.submitted?
+        submitted_years = AgencyStatus.find_or_create_by_ori(ori).complete_submission_years
+        if submitted_years.include? year
+          record.errors[attribute] << "ORI #{ori} has already submitted for this year"
+        end
+      end
+    end
 end

--- a/app/validators/ori_validator.rb
+++ b/app/validators/ori_validator.rb
@@ -1,10 +1,10 @@
 # Validates that the incident ORI is allowed.
 class OriValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    ori = value || record.default_ori
-    current_user = User.where(user_id: record.current_user_id).first if record.current_user_id
+    ori = value || record.incident.target.try(:ori)
+    user = record.incident.target.try(:user)
 
-    if current_user && current_user.allowed_oris.exclude?(ori)
+    if user && user.allowed_oris.exclude?(ori)
       record.errors[attribute] << "invalid ORI: #{ori}"
     end
   end

--- a/app/validators/ori_validator.rb
+++ b/app/validators/ori_validator.rb
@@ -1,0 +1,11 @@
+# Validates that the incident ORI is allowed.
+class OriValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    ori = value || record.default_ori
+    current_user = User.where(user_id: record.current_user_id).first
+
+    if current_user.allowed_oris.exclude? ori
+      record.errors[attribute] << "invalid ORI: #{ori}"
+    end
+  end
+end

--- a/app/validators/ori_validator.rb
+++ b/app/validators/ori_validator.rb
@@ -2,9 +2,9 @@
 class OriValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     ori = value || record.default_ori
-    current_user = User.where(user_id: record.current_user_id).first
+    current_user = User.where(user_id: record.current_user_id).first if record.current_user_id
 
-    if current_user.allowed_oris.exclude? ori
+    if current_user && current_user.allowed_oris.exclude?(ori)
       record.errors[attribute] << "invalid ORI: #{ori}"
     end
   end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -222,7 +222,7 @@ module Helpers
 
   def submit_to_state
     visit_status :state_submission
-    click_button 'FINAL SUBMISSION'
+    click_button 'SUBMISSION'
   end
 
   # Visit the dashboard page showing incidents of the given status

--- a/spec/requests/general_info_spec.rb
+++ b/spec/requests/general_info_spec.rb
@@ -40,7 +40,7 @@ describe '[General Info Page]', type: :request do
     expect_form_success
   end
 
-  it 'continues to the next page when complete' do
+  it "doesn't allow incidents with years that have already been submitted for" do
     AgencyStatus.find_or_create_by_ori(User.first.ori)
                 .mark_year_submitted!(Time.current.year - 1)
 

--- a/spec/requests/general_info_spec.rb
+++ b/spec/requests/general_info_spec.rb
@@ -40,6 +40,16 @@ describe '[General Info Page]', type: :request do
     expect_form_success
   end
 
+  it 'continues to the next page when complete' do
+    AgencyStatus.find_or_create_by_ori(User.first.ori)
+                .mark_year_submitted!(Time.current.year - 1)
+
+    answer_all_general_info
+    find('button[type=submit]').click
+
+    expect_form_failure
+  end
+
   it 'allows partial save', driver: :poltergeist do
     today_str = Time.zone.today.strftime('%m/%d/%Y')
     fill_in 'Date', with: today_str

--- a/spec/requests/general_info_spec.rb
+++ b/spec/requests/general_info_spec.rb
@@ -44,7 +44,7 @@ describe '[General Info Page]', type: :request do
     AgencyStatus.find_or_create_by_ori(User.first.ori)
                 .mark_year_submitted!(Time.current.year - 1)
 
-    answer_all_general_info
+    answer_all_general_info(date: Time.zone.today - 1.year)
     find('button[type=submit]').click
 
     expect_form_failure

--- a/spec/requests/incident_with_contracting_oris_and_state_submission_spec.rb
+++ b/spec/requests/incident_with_contracting_oris_and_state_submission_spec.rb
@@ -98,7 +98,7 @@ describe '[Incident with contracting ORI relationships]' do
     it 'before the window is opened, has no submission button and renders the right message' do
       visit_status :state_submission
       expect(page).to have_content("not yet open")
-      expect(page).not_to have_button('FINAL SUBMISSION')
+      expect(page).not_to have_button('SUBMISSION')
     end
 
     it 'allows state submission during the submission window' do
@@ -109,7 +109,7 @@ describe '[Incident with contracting ORI relationships]' do
       visit_status :state_submission
       expect(page).to have_content("1 incident ready for state submission")
       expect(page).to have_content("You may now submit incidents")
-      click_button 'FINAL SUBMISSION'
+      click_button 'SUBMISSION'
 
       expect(AgencyStatus.where(ori: @parent_ori_admin.ori).first.last_submission_year).to eq(@current_submission_year)
       expect(AgencyStatus.where(ori: @sub_ori_user.ori).first.last_submission_year).to eq(@current_submission_year)
@@ -126,7 +126,7 @@ describe '[Incident with contracting ORI relationships]' do
 
       # Disables subsequent state submission
       visit_status :state_submission
-      expect(page).not_to have_button('FINAL SUBMISSION')
+      expect(page).not_to have_button('SUBMISSION')
       expect(page).to have_content("Submission complete")
     end
 

--- a/spec/requests/splash_page_spec.rb
+++ b/spec/requests/splash_page_spec.rb
@@ -5,13 +5,11 @@ describe '[Splash page]', type: :request do
     login(dont_handle_splash: true)
     visit root_path
     expect(current_path).to end_with('/welcome')
-    expect(page).to have_content('Welcome')
 
     # Until the user clicks 'ENTER' on the splash page, they'll keep getting
     # redirected there
     visit root_path
     expect(current_path).to end_with('/welcome')
-    expect(page).to have_content('Welcome')
 
     click_button('ENTER')
     expect(current_path).not_to end_with('/welcome')  # Sent away from splash

--- a/spec/requests/splash_page_spec.rb
+++ b/spec/requests/splash_page_spec.rb
@@ -5,13 +5,13 @@ describe '[Splash page]', type: :request do
     login(dont_handle_splash: true)
     visit root_path
     expect(current_path).to end_with('/welcome')
-    expect(page).to have_content('Welcome to URSUS')
+    expect(page).to have_content('Welcome')
 
     # Until the user clicks 'ENTER' on the splash page, they'll keep getting
     # redirected there
     visit root_path
     expect(current_path).to end_with('/welcome')
-    expect(page).to have_content('Welcome to URSUS')
+    expect(page).to have_content('Welcome')
 
     click_button('ENTER')
     expect(current_path).not_to end_with('/welcome')  # Sent away from splash


### PR DESCRIPTION
Also fixes a bug with the ORI validation in `general_infos_controller.rb` – I don't think it was being done correctly before.
