### PR TITLE
Add a 'test' that monitors the read/write capacity used by common tasks

### DIFF
--- a/spec/requests/db_capacity_spec.rb
+++ b/spec/requests/db_capacity_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe '[DB Capacity]', type: :request do
+  it 'check the amount of DynamoDB read/write capacity used in performing basic tasks' do
+    Dynamoid.adapter.monitor("Log in") do
+      login
+    end
+
+    Dynamoid.adapter.monitor("Create an incident w/ 1 civilian and 1 officer") do
+      create_complete_incident
+    end
+
+    Dynamoid.adapter.monitor("Review an incident") do
+      visit_status :in_review
+      click_link "View"
+    end
+
+    Dynamoid.adapter.monitor("Create an incident w/ 3 civilians and 3 officers") do
+      create_complete_incident 3, 3
+    end
+  end
+end
+
+module Dynamoid
+  class Adapter
+    attr_reader :read_capacity_used, :write_capacity_used
+
+    # Given a block monitor the read and write capacity taken
+    # to execute the task.
+    def monitor(description)
+      puts ""
+      puts "(#{description})"
+
+      @read_capacity_used = Hash.new { |h, k| h[k] = 0 }
+      @write_capacity_used = Hash.new { |h, k| h[k] = 0 }
+
+      yield
+
+      puts "  Read capacity used: #{Dynamoid.adapter.read_capacity_used.values.reduce(:+)}"
+      Dynamoid.adapter.read_capacity_used.each do |table, capacity|
+        puts "    #{table}: #{capacity}"
+      end
+
+      puts "  Write capacity used: #{Dynamoid.adapter.write_capacity_used.values.reduce(:+)}"
+      Dynamoid.adapter.write_capacity_used.each do |table, capacity|
+        puts "    #{table}: #{capacity}"
+      end
+    end
+
+    # DynamoDB's built-in `Adapter#benchmark` method simply times operations.
+    # Instead, let's benchmark read/write capacity usage.
+    def benchmark(method, *args)
+      result = yield
+
+      if args
+        case method
+        when 'get_item'
+          @read_capacity_used[args[0][0]] += 1
+        when 'put_item'
+          @write_capacity_used[args[0][0]] += 1
+        when 'batch_get_item'
+          args[0].each do |table, ids|
+            @read_capacity_used[table] += ids.length if ids
+          end
+        when 'Scan'
+          result.each do
+            @read_capacity_used[args[0]] += 1
+          end
+          result.rewind
+        end
+      end
+
+      result
+    end
+  end
+end

--- a/spec/requests/db_capacity_spec.rb
+++ b/spec/requests/db_capacity_spec.rb
@@ -34,7 +34,9 @@ module Dynamoid
       @read_capacity_used = Hash.new { |h, k| h[k] = 0 }
       @write_capacity_used = Hash.new { |h, k| h[k] = 0 }
 
+      @monitoring = true
       yield
+      @monitoring = false
 
       puts "  Read capacity used: #{Dynamoid.adapter.read_capacity_used.values.reduce(:+)}"
       Dynamoid.adapter.read_capacity_used.each do |table, capacity|
@@ -52,7 +54,7 @@ module Dynamoid
     def benchmark(method, *args)
       result = yield
 
-      if args
+      if @monitoring && args
         case method
         when 'get_item'
           @read_capacity_used[args[0][0]] += 1


### PR DESCRIPTION
This PR gets us a little closer to understanding our DynamoDB read/write capacity usage, which in turn will help determine how best to configure our DynamoDB tables.

Going off of the [DynamoDB documentation](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html) and [this StackOverflow thread](http://stackoverflow.com/questions/20999465/dynamodb-reading-and-writing-units), it seems that each capacity unit allows 1 item read/written per second. What my monitoring code does is output how many reads/writes are needed to perform each given operation.

If this is true, and, say, we want to allow a maximum incident creation rate of 1 incident per second, then, judging from the output below, we would want the `incidents` table to have at minimum 32 read capacity units and 17 write capacity units, etc.

Some caveats:
1. I'm not 100% sure that I'm understanding how these limits work exactly, because if this is true, our demo app shouldn't even really be usable with 1 read + 1 write capacity unit per table ...
2. The amount of items in a given table would affect some of these capacity results, I think. Though I'm still not sure exactly how queries and scans use capacity, even after reading [this](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScanGuidelines.html).

The output I get running `dc run test spec/requests/db_capacity_spec.rb` is:

```
(Log in)
  Read capacity used: 5
    ursus_test_users: 4
    ursus_test_agencystatuses: 1
  Write capacity used: 24
    ursus_test_users: 6
    ursus_test_visits: 3
    ursus_test_events: 15

(Create an incident w/ 1 civilian and 1 officer)
  Read capacity used: 198
    ursus_test_users: 49
    ursus_test_incidents: 32
    ursus_test_screeners: 12
    ursus_test_globalstates: 59
    ursus_test_agencystatuses: 26
    ursus_test_general_infos: 12
    ursus_test_involved_civilians: 6
    ursus_test_involved_officers: 2
  Write capacity used: 233
    ursus_test_events: 85
    ursus_test_users: 18
    ursus_test_screeners: 2
    ursus_test_incidents: 17
    ursus_test_auditentries: 57
    ursus_test_globalstates: 1
    ursus_test_agencystatuses: 1
    ursus_test_general_infos: 2
    ursus_test_changedfields: 46
    ursus_test_involved_civilians: 2
    ursus_test_involved_officers: 2

(Review an incident)
  Read capacity used: 45
    ursus_test_agencystatuses: 7
    ursus_test_incidents: 5
    ursus_test_general_infos: 3
    ursus_test_users: 12
    ursus_test_screeners: 2
    ursus_test_globalstates: 12
    ursus_test_involved_civilians: 2
    ursus_test_involved_officers: 2
  Write capacity used: 18
    ursus_test_events: 15
    ursus_test_users: 3

(Create an incident w/ 3 civilians and 3 officers)
  Read capacity used: 420
    ursus_test_users: 102
    ursus_test_incidents: 73
    ursus_test_screeners: 28
    ursus_test_globalstates: 122
    ursus_test_agencystatuses: 58
    ursus_test_general_infos: 29
    ursus_test_involved_civilians: 4
    ursus_test_involved_officers: 4
  Write capacity used: 451
    ursus_test_events: 165
    ursus_test_users: 34
    ursus_test_screeners: 2
    ursus_test_incidents: 25
    ursus_test_auditentries: 117
    ursus_test_general_infos: 2
    ursus_test_changedfields: 94
    ursus_test_involved_civilians: 6
    ursus_test_involved_officers: 6
```
