### PR TITLE
Fix circle.yml to use bridge ECS instead of ursus ECS

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -51,6 +51,6 @@ deployment:
   master:
     branch: master
     commands:
-      - $(aws ecr get-login)
+      - $(aws ecr get-login --region us-west-1)
       - GIT_SHA1=$CIRCLE_SHA1 docker-compose build web
-      - docker push ${DOCKER_REGISTRY_PATH}bridge:latest
+      - docker push ${DOCKER_REGISTRY_PATH}bridge-uof:latest


### PR DESCRIPTION
I made another repository called "bridge-uof" on amazon container service, and now am changing circle.yml to push to it. The DOCKER_REGISTRY_PATH remains unchanged.