### PR TITLE
Create GeneralInfo reverse association after incident bulk upload / factory creation

### DIFF
--- a/app/services/incident_deserializer_service.rb
+++ b/app/services/incident_deserializer_service.rb
@@ -38,7 +38,7 @@ class IncidentDeserializerService
   def self.create_incident!(user, ori, screener, general_info, involved_civilians, involved_officers)
     incident = Incident.create(user: user, ori: ori)
     begin
-      # Populate the incidents.
+      # Populate the incident.
       incident.screener = screener
       incident.general_info = general_info
       incident.involved_civilians = involved_civilians

--- a/app/services/incident_deserializer_service.rb
+++ b/app/services/incident_deserializer_service.rb
@@ -44,8 +44,8 @@ class IncidentDeserializerService
       incident.involved_civilians = involved_civilians
       incident.involved_officers = involved_officers
 
-      # Set additional things:
-      # incident ID, audit entries, backwards association (needed for GeneralInfo)
+      # Set some additional things:
+      # incident ID, audit entry, backwards association (needed for GeneralInfo)
       incident.incident_id.generate!
       incident.audit_entries << AuditEntry.new(user: user, custom_text: 'imported this incident')
       incident.general_info.incident = incident

--- a/spec/factories/general_info.rb
+++ b/spec/factories/general_info.rb
@@ -16,5 +16,6 @@ FactoryGirl.define do
     contact_reason GeneralInfo::CONTACT_REASONS[0]
     num_involved_civilians 1
     num_involved_officers 1
+    ori { build(:dummy_user).ori }
   end
 end

--- a/spec/factories/incident.rb
+++ b/spec/factories/incident.rb
@@ -33,6 +33,14 @@ FactoryGirl.define do
           incident.in_review! if e.submit
         end
       end
+
+      incident.general_info.incident = incident
+      # All of the below lines are needed, or else the "2-way association" test fails. WTF
+      incident.general_info.incident.target
+      incident.general_info.incident.screener.target
+      incident.general_info.incident.general_info.target
+      incident.general_info.incident.involved_civilians.target
+      incident.general_info.incident.involved_officers.target
     end
   end
 end

--- a/spec/requests/incident_spec.rb
+++ b/spec/requests/incident_spec.rb
@@ -16,6 +16,7 @@ describe '[Incident]', type: :request do
 
     it 'smoke test -- create a complete incident, send for review' do
       create_complete_incident
+      p Incident.first.general_info.incident.target
     end
 
     it 'does not create incidents until the screener page is filled out' do

--- a/spec/requests/incident_spec.rb
+++ b/spec/requests/incident_spec.rb
@@ -16,7 +16,6 @@ describe '[Incident]', type: :request do
 
     it 'smoke test -- create a complete incident, send for review' do
       create_complete_incident
-      p Incident.first.general_info.incident.target
     end
 
     it 'does not create incidents until the screener page is filled out' do


### PR DESCRIPTION
Due to some mystical interaction between Dynamoid and FactoryGirl, incidents that are deserialized or factory-created do not have reverse associations set like manually-created incidents do (see #42).

This PR adds a test for this and makes the test pass, at the cost of some really disgusting code (I seriously don't know how it works and why some of these lines are necessary). I don't really want to drop this into master, but I'm at my wits' end as to how else to get this working.