### PR TITLE
Fix the creation of reverse relations in bulk upload.

### DIFF
--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -116,7 +116,7 @@ class IncidentsController < ApplicationController
       @current_user.incidents << incident
       @current_user.save
 
-      incident.update_attribute(:ori, @current_user.ori)
+      incident.general_info.update_attribute(:ori, @current_user.ori)
       incident.approved!
     end
 

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -22,7 +22,7 @@ class Incident
 
   global_secondary_index hash_key: :incident_id_str, projected_attributes: [hash_key]
 
-  validates :user, :ori, presence: true
+  validates :user, presence: true
   validates :incident_id_str, uniqueness: true, allow_nil: true
 
   # For convenience, we programmatically create a set of getters draft?, in_review?, etc.
@@ -122,7 +122,6 @@ class Incident
     raise "Incident is not complete" unless complete?
 
     {
-      ori: ori,
       screener: screener.to_hash,
       general_info: general_info.to_hash,
       involved_civilians: involved_civilians.map(&:to_hash),
@@ -132,7 +131,6 @@ class Incident
 
   def self.json_schema
     raw_json_schema = {
-      'ori' => '<string>',
       'screener' => Screener.json_schema,
       'general_info' => GeneralInfo.json_schema,
       'involved_civilians[]' => InvolvedCivilian.json_schema,
@@ -150,7 +148,6 @@ class Incident
       <?xml version="1.0" encoding="UTF-8"?>
       <incidents type="array">
         <incident>
-          <ori>{{ string }}</ori>
           <screener>
             #{Screener.xml_schema}
           </screener>

--- a/app/services/incident_deserializer_service.rb
+++ b/app/services/incident_deserializer_service.rb
@@ -38,19 +38,6 @@ class IncidentDeserializerService
   def self.create_incident!(user, screener, general_info, involved_civilians, involved_officers)
     incident = Incident.create(user: user)
     begin
-      screener.incident = incident
-      screener.save!
-      general_info.incident = incident
-      general_info.save!
-      incident.involved_civilians.each do |civ|
-        civ.incident = incident
-        civ.save!
-      end
-      incident.involved_officers.each do |officer|
-        officer.incident = incident
-        officer.save!
-      end
-
       incident.screener = screener
       incident.general_info = general_info
       incident.involved_civilians = involved_civilians

--- a/app/services/incident_deserializer_service.rb
+++ b/app/services/incident_deserializer_service.rb
@@ -2,19 +2,19 @@
 class IncidentDeserializerService
   def self.from_hash(hash, user)
     begin
-      ori = Rails.configuration.x.login.use_demo? ? user.ori : hash['ori']  # Ignore 'ori' field in DEMO auth mode.
       screener = Screener.from_hash(hash.fetch('screener'))
       general_info = GeneralInfo.from_hash(hash.fetch('general_info'))
+      general_info.ori = user.ori if Rails.configuration.x.login.use_demo?  # Ignore 'ori' field in DEMO auth mode.
       involved_civilians = hash.fetch('involved_civilians').map { |c| InvolvedCivilian.from_hash(c) }
       involved_officers = hash.fetch('involved_officers').map { |c| InvolvedOfficer.from_hash(c) }
     rescue => e
       raise generate_nicer_parsing_exception_message(e)
     end
 
-    validate_ori(user, ori)
+    validate_ori(user, general_info.ori)
     validate_steps(screener, general_info, involved_civilians, involved_officers)
 
-    create_incident!(user, ori, screener, general_info, involved_civilians, involved_officers)
+    create_incident!(user, screener, general_info, involved_civilians, involved_officers)
   rescue => e
     # If anything went wrong, clean up any persisted state if necessary,
     # then propagate the error.
@@ -35,9 +35,22 @@ class IncidentDeserializerService
     end
   end
 
-  def self.create_incident!(user, ori, screener, general_info, involved_civilians, involved_officers)
-    incident = Incident.create(user: user, ori: ori)
+  def self.create_incident!(user, screener, general_info, involved_civilians, involved_officers)
+    incident = Incident.create(user: user)
     begin
+      screener.incident = incident
+      screener.save!
+      general_info.incident = incident
+      general_info.save!
+      incident.involved_civilians.each do |civ|
+        civ.incident = incident
+        civ.save!
+      end
+      incident.involved_officers.each do |officer|
+        officer.incident = incident
+        officer.save!
+      end
+
       incident.screener = screener
       incident.general_info = general_info
       incident.involved_civilians = involved_civilians

--- a/spec/factories/general_info.rb
+++ b/spec/factories/general_info.rb
@@ -16,5 +16,6 @@ FactoryGirl.define do
     contact_reason GeneralInfo::CONTACT_REASONS[0]
     num_involved_civilians 1
     num_involved_officers 1
+    ori { build(:dummy_user).ori }
   end
 end

--- a/spec/factories/incident.rb
+++ b/spec/factories/incident.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
       num_officers  1
       submit        true
       stop_step     nil
+      ori           nil
     end
 
     user { User.find_by_user_id(user_id) || create(:dummy_user) }
@@ -13,7 +14,7 @@ FactoryGirl.define do
     after(:create) do |incident, e|  # e is the FactoryGirl evaluator (has access to transient attributes).
       incident.screener = create :screener
 
-      incident.general_info = create(:general_info) do |g|
+      incident.general_info = create(:general_info, ori: e.ori || incident.user.ori) do |g|
         g.update_attributes(
           num_involved_civilians: e.num_civilians,
           num_involved_officers: e.num_officers

--- a/spec/requests/serialization_spec.rb
+++ b/spec/requests/serialization_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe '[Incident serialization and bulk upload]', type: :request do
   let(:incident) { create(:incident, &:destroy) }
   let(:valid_json) { incident.to_hash.to_json }
+  let(:deserialized_incident) { Incident.from_hash(JSON.parse(valid_json), user) }
   let(:user) { User.first }
 
   before :each do
@@ -10,12 +11,17 @@ describe '[Incident serialization and bulk upload]', type: :request do
   end
 
   it 'serializes and deserializes incidents properly' do
-    deserialized_incident = Incident.from_hash(JSON.parse(valid_json), user)
-
-    expect(deserialized_incident).to be(incident)
+    expect(deserialized_incident).to be_present
     expect(deserialized_incident.audit_entries.count).to eq(1)
     expect(deserialized_incident.audit_entries[0].user.id).to eq(user.id)
     expect(deserialized_incident.audit_entries[0].custom_text).to eq('imported this incident')
+  end
+
+  it 'maintains a 2-way association between Incident and GeneralInfo for factory-created and deserialized incidents' do
+    expect(deserialized_incident.screener.incident.target).to be(deserialized_incident)
+    expect(deserialized_incident.general_info.incident.target).to be(deserialized_incident)
+    expect(deserialized_incident.involved_civilians[0].incident.target).to be(deserialized_incident)
+    expect(deserialized_incident.involved_officers[0].incident.target).to be(deserialized_incident)
   end
 
   it 'throws descriptive errors on validation failure' do

--- a/test.json
+++ b/test.json
@@ -1,6 +1,5 @@
 [
   {
-    "ori": "CA0190000",
     "screener": {
       "partial": "f",
       "multiple_agencies": "f",
@@ -12,7 +11,7 @@
     },
     "general_info": {
       "partial": "f",
-      "ori": null,
+      "ori": "CA0190000",
       "incident_date_str": "04\/01\/2016",
       "incident_time_str": "1830",
       "address": "1355 Market St",
@@ -88,7 +87,6 @@
     ]
   },
   {
-    "ori": "CA0190000",
     "screener": {
       "partial": "f",
       "multiple_agencies": "f",
@@ -100,7 +98,7 @@
     },
     "general_info": {
       "partial": "f",
-      "ori": null,
+      "ori": "CA0190000",
       "incident_date_str": "02\/01\/2016",
       "incident_time_str": "1830",
       "address": "1355 Market St",


### PR DESCRIPTION
Fixes #42

So, the problem is that Dynamoid doesn't properly update reverse associations in some circumstances. If you have, say, an `incident` object and do `incident.screener = some_screener`, it correctly sets `incident.screener_ids` to the id of the screener object, but does not change the screener's `incident_ids` object, which remains nil. The reverse is also true.

However, if you pass one object into the other's constructor (e.g. `screener = Screener.new(..., incident: incident)`) it will set the associations correctly.

I spent some time in the Dynamoid code, and couldn't quite figure out where in the association code it was failing to set the reverse. Still looking now, since this would be a better fix to avoid mystery errors in the future.