### PR TITLE
Fix corner case for Duplicate incidents

### DIFF
--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -77,11 +77,7 @@ class IncidentsController < ApplicationController
   end
 
   def destroy
-    if Rails.configuration.x.login.use_demo?
-      @incident.destroy
-    else
-      save_and_audit(@incident, status: 'deleted')
-    end
+    save_and_audit(@incident, status: 'deleted')
     redirect_to dashboard_url(status: @status)
   end
 

--- a/app/models/general_info.rb
+++ b/app/models/general_info.rb
@@ -54,7 +54,7 @@ class GeneralInfo
                                       incident_time_str: incident_time_str,
                                       incident_date_str: incident_date_str)
 
-    if general_infos.any? { |gi| gi.id != id && !gi.incident.try(:target).try(:deleted?) }
+    if general_infos.any? { |gi| gi.id != id && !gi.partial && !gi.incident.try(:target).try(:deleted?) }
       errors.add(:address, "there is already another incident with this same date, time, address, city, and ORI - are you sure you didn't fill out this incident report already?")
     end
   end

--- a/spec/models/general_info_spec.rb
+++ b/spec/models/general_info_spec.rb
@@ -5,6 +5,13 @@ describe GeneralInfo, type: :model do
     let(:incident) { create(:incident) }
     let(:gi) { incident.general_info }
 
+    def create_duplicate
+      create(:general_info, ori: gi.ori, city: gi.city,
+                            address: gi.address,
+                            incident_date_str: gi.incident_date_str,
+                            incident_time_str: gi.incident_time_str)
+    end
+
     it 'validates a model with all correct fields' do
       expect(gi.valid?).to be true
     end
@@ -40,37 +47,21 @@ describe GeneralInfo, type: :model do
 
     it 'does not raise uniqueness validation if incident status is deleted' do
       incident.update_attribute(:status, 'deleted')
-      duplicate = build(:general_info, ori: gi.ori, city: gi.city,
-                                       address: gi.address,
-                                       incident_date_str: gi.incident_date_str,
-                                       incident_time_str: gi.incident_time_str)
-      expect { duplicate.save! }.not_to raise_error
+      expect { create_duplicate }.not_to raise_error
     end
 
     it 'does not raise uniqueness validation if duplicate GeneralInfo is a partial save' do
       gi.partial_save({})
-      duplicate = build(:general_info, ori: gi.ori, city: gi.city,
-                                       address: gi.address,
-                                       incident_date_str: gi.incident_date_str,
-                                       incident_time_str: gi.incident_time_str)
-      expect { duplicate.save! }.not_to raise_error
+      expect { create_duplicate }.not_to raise_error
     end
 
     it 'raises uniqueness validation of general info based on ori, city, address, date, and time if incident without deleted incident' do
-      duplicate = build(:general_info, ori: gi.ori, city: gi.city,
-                                       address: gi.address,
-                                       incident_date_str: gi.incident_date_str,
-                                       incident_time_str: gi.incident_time_str)
-      expect { duplicate.save! }.to raise_error(/there is already another incident with this same date, time, address, city, and ORI - are you sure you didn't fill out this incident report already?/)
+      expect { create_duplicate }.to raise_error(/there is already another incident with this same date, time, address, city, and ORI - are you sure you didn't fill out this incident report already?/)
     end
 
     it 'raise uniqueness validation if incident deleted' do
       incident.delete
-      duplicate = build(:general_info, ori: gi.ori, city: gi.city,
-                                       address: gi.address,
-                                       incident_date_str: gi.incident_date_str,
-                                       incident_time_str: gi.incident_time_str)
-      expect { duplicate.save! }.to raise_error(/there is already another incident with this same date, time, address, city, and ORI - are you sure you didn't fill out this incident report already?/)
+      expect { create_duplicate }.to raise_error(/there is already another incident with this same date, time, address, city, and ORI - are you sure you didn't fill out this incident report already?/)
     end
 
     describe "[address]" do

--- a/spec/models/general_info_spec.rb
+++ b/spec/models/general_info_spec.rb
@@ -5,7 +5,7 @@ describe GeneralInfo, type: :model do
     let(:incident) { create(:incident) }
     let(:gi) { incident.general_info }
 
-    def create_duplicate
+    def create_duplicate!
       create(:general_info, ori: gi.ori, city: gi.city,
                             address: gi.address,
                             incident_date_str: gi.incident_date_str,
@@ -47,21 +47,21 @@ describe GeneralInfo, type: :model do
 
     it 'does not raise uniqueness validation if incident status is deleted' do
       incident.update_attribute(:status, 'deleted')
-      expect { create_duplicate }.not_to raise_error
+      expect { create_duplicate! }.not_to raise_error
     end
 
     it 'does not raise uniqueness validation if duplicate GeneralInfo is a partial save' do
       gi.partial_save({})
-      expect { create_duplicate }.not_to raise_error
+      expect { create_duplicate! }.not_to raise_error
     end
 
     it 'raises uniqueness validation of general info based on ori, city, address, date, and time if incident without deleted incident' do
-      expect { create_duplicate }.to raise_error(/there is already another incident with this same date, time, address, city, and ORI - are you sure you didn't fill out this incident report already?/)
+      expect { create_duplicate! }.to raise_error(/there is already another incident with this same date, time, address, city, and ORI - are you sure you didn't fill out this incident report already?/)
     end
 
     it 'raise uniqueness validation if incident deleted' do
       incident.delete
-      expect { create_duplicate }.to raise_error(/there is already another incident with this same date, time, address, city, and ORI - are you sure you didn't fill out this incident report already?/)
+      expect { create_duplicate! }.to raise_error(/there is already another incident with this same date, time, address, city, and ORI - are you sure you didn't fill out this incident report already?/)
     end
 
     describe "[address]" do

--- a/spec/models/general_info_spec.rb
+++ b/spec/models/general_info_spec.rb
@@ -47,6 +47,15 @@ describe GeneralInfo, type: :model do
       expect { duplicate.save! }.not_to raise_error
     end
 
+    it 'does not raise uniqueness validation if duplicate GeneralInfo is a partial save' do
+      gi.partial_save({})
+      duplicate = build(:general_info, ori: gi.ori, city: gi.city,
+                                       address: gi.address,
+                                       incident_date_str: gi.incident_date_str,
+                                       incident_time_str: gi.incident_time_str)
+      expect { duplicate.save! }.not_to raise_error
+    end
+
     it 'raises uniqueness validation of general info based on ori, city, address, date, and time if incident without deleted incident' do
       duplicate = build(:general_info, ori: gi.ori, city: gi.city,
                                        address: gi.address,


### PR DESCRIPTION
1. Change demo mode to mark incidents as deleted, instead of actual destruction, so that we can surface this issue in demo mode (and so demo mode more fully reflects reality, as I use demo mode often for manual testing). If the user resets the demo, incidents will all be deleted anyway.
1. Here's the issue.
   1. Create a complete incident. Send it for review.
   1. Create a second incident. On the GeneralInfo page, enter the same details as the first incident. Click the "I'm not done yet..." button to partially save.
   1. Go back to view the first incident, which should be in review. Click View. Instead of the review page, it will take you to the GeneralInfo page, with an error about a duplicate incident.